### PR TITLE
[PR] 인증 메일 발송 API 구현

### DIFF
--- a/server/src/db/context/verifications.ts
+++ b/server/src/db/context/verifications.ts
@@ -16,11 +16,13 @@ const insertVerification = async (email: string, code: string) => {
 /**
  * 인증 번호 조회
  */
-const getVerificationByEmail = async (email: string) => {
+const getVerificationByValue = async (value: string | number) => {
+	const column = typeof value === "string" ? "email" : "id";
+
 	const connection = await connectDB();
 	const [rows] = await connection.query(
-		`SELECT * FROM verifications WHERE email=?`,
-		[email]
+		`SELECT * FROM verifications WHERE ${column}=?`,
+		[value]
 	);
 
 	return rows;
@@ -61,7 +63,7 @@ const deleteVerification = async (id: number) => {
 
 export {
 	insertVerification,
-	getVerificationByEmail,
+	getVerificationByValue,
 	updateVerification,
 	deleteVerification,
 };

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -5,16 +5,25 @@ import {
 	insertVerification,
 	deleteVerification,
 	updateVerification,
-	getVerificationByEmail,
+	getVerificationByValue,
 } from "../db/context/verifications";
 
 dotenv.config();
 
 /**
- * 인증 번호 조회
+ * 인증 번호 조회 by email
  */
 const findVerificationByEmail = async (email: string): Promise<object> => {
-	const result = await getVerificationByEmail(email);
+	const result = await getVerificationByValue(email);
+
+	return result;
+};
+
+/**
+ * 인증 번호 조회 by id
+ */
+const findVerificationById = async (id: number): Promise<object> => {
+	const result = await getVerificationByValue(id);
 
 	return result;
 };
@@ -44,12 +53,12 @@ const updateExistingVerification = async (id: number) => {
  */
 const removeVerificationById = async (id: number) => {
 	const result = await deleteVerification(id);
-	console.log(result);
 	return result;
 };
 
 export {
 	findVerificationByEmail,
+	findVerificationById,
 	createNewVerification,
 	updateExistingVerification,
 	removeVerificationById,

--- a/server/src/services/mail.ts
+++ b/server/src/services/mail.ts
@@ -11,7 +11,7 @@ let transporter: Transporter | null = null;
 /**
  * 인증 메일 발송
  */
-const sendAuthMail = async (to: string, ranNum: string) => {
+const sendAuthMail = async (to: string, code: string) => {
 	if (!transporter) {
 		transporter = createTransport(smtpconfig);
 	}
@@ -20,7 +20,7 @@ const sendAuthMail = async (to: string, ranNum: string) => {
 		from: process.env.NODEMAILER_EMAIL,
 		to,
 		subject: "live-chat 인증 번호 발송 메일",
-		text: `인증 번호 : ${ranNum}`,
+		text: `인증 번호 : ${code.split("").join(" ")}`,
 	};
 
 	return await transporter.sendMail(mailOptions);

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -10,6 +10,15 @@ interface IAffectedRows {
 	affectedRows: number;
 }
 
+interface IVerificationShema {
+	id: number;
+	email: string;
+	code: string;
+	expired_at: Date;
+	created_at: Date;
+	updated_at: Date;
+}
+
 // express 관련 타입 및 인터페이스
 interface IRequest extends Request {
 	registerInfo: IRegisterTokenPayload;
@@ -26,4 +35,11 @@ interface IError extends Error {
 	statusCode?: number;
 }
 
-export { IInsertId, IAffectedRows, IRequest, IRegisterTokenPayload, IError };
+export {
+	IInsertId,
+	IAffectedRows,
+	IVerificationShema,
+	IRequest,
+	IRegisterTokenPayload,
+	IError,
+};


### PR DESCRIPTION
## ✨ Summary

-   회원가입 토큰 검증 후 인증 메일 발송

## ✍🏻 Describe changes

- #6 재구현

### controller

- 인증 번호 조회 -> 미들웨어로 분리 예정
- 토큰 발급 및 쿠키 설정
- 요청 처리

### service

- mail.ts: 메일 발송 함수 인수명 변경
- auth.ts: id와 email 별로 인증 번호 조회를 가능하도록 함수 분리

### db

- verifications.ts : verifications 테이블에 대한 row 조회를 id와 email로 가능하게 변경

### 이외

- db 결과에 대한 타입 정의

## 📌 Issue number

resolved: #2 
