### PR TITLE
[PR] 로그인 API 구현

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,19 +12,23 @@
 				"cookie-parser": "^1.4.6",
 				"dotenv": "^16.4.5",
 				"express": "^4.19.2",
+				"express-session": "^1.18.0",
 				"express-validator": "^7.1.0",
 				"http-status-codes": "^2.3.0",
 				"jsonwebtoken": "^9.0.2",
 				"mysql2": "^3.10.2",
 				"nodemailer": "^6.9.14",
-				"socket.io": "^4.7.5"
+				"socket.io": "^4.7.5",
+				"uuid": "^10.0.0"
 			},
 			"devDependencies": {
 				"@types/cookie-parser": "^1.4.7",
 				"@types/express": "^4.17.21",
+				"@types/express-session": "^1.18.0",
 				"@types/jsonwebtoken": "^9.0.6",
 				"@types/node": "^20.14.10",
 				"@types/nodemailer": "^6.4.15",
+				"@types/uuid": "^10.0.0",
 				"nodemon": "^3.1.4",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.5.3"
@@ -161,6 +165,15 @@
 				"@types/send": "*"
 			}
 		},
+		"node_modules/@types/express-session": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.0.tgz",
+			"integrity": "sha512-27JdDRgor6PoYlURY+Y5kCakqp5ulC0kmf7y+QwaY+hv9jEFuQOThgkjyA53RP3jmKuBsH5GR6qEfFmvb8mwOA==",
+			"dev": true,
+			"dependencies": {
+				"@types/express": "*"
+			}
+		},
 		"node_modules/@types/http-errors": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -231,6 +244,12 @@
 				"@types/node": "*",
 				"@types/send": "*"
 			}
+		},
+		"node_modules/@types/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+			"dev": true
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -713,6 +732,29 @@
 			"engines": {
 				"node": ">= 0.10.0"
 			}
+		},
+		"node_modules/express-session": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
+			"integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
+			"dependencies": {
+				"cookie": "0.6.0",
+				"cookie-signature": "1.0.7",
+				"debug": "2.6.9",
+				"depd": "~2.0.0",
+				"on-headers": "~1.0.2",
+				"parseurl": "~1.3.3",
+				"safe-buffer": "5.2.1",
+				"uid-safe": "~2.1.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/express-session/node_modules/cookie-signature": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
 		},
 		"node_modules/express-validator": {
 			"version": "7.1.0",
@@ -1318,6 +1360,14 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/on-headers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1373,6 +1423,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/random-bytes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+			"integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/range-parser": {
@@ -1767,6 +1825,17 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/uid-safe": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+			"integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+			"dependencies": {
+				"random-bytes": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/undefsafe": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -1792,6 +1861,18 @@
 			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/v8-compile-cache-lib": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,19 +11,23 @@
 		"cookie-parser": "^1.4.6",
 		"dotenv": "^16.4.5",
 		"express": "^4.19.2",
+		"express-session": "^1.18.0",
 		"express-validator": "^7.1.0",
 		"http-status-codes": "^2.3.0",
 		"jsonwebtoken": "^9.0.2",
 		"mysql2": "^3.10.2",
 		"nodemailer": "^6.9.14",
-		"socket.io": "^4.7.5"
+		"socket.io": "^4.7.5",
+		"uuid": "^10.0.0"
 	},
 	"devDependencies": {
 		"@types/cookie-parser": "^1.4.7",
 		"@types/express": "^4.17.21",
+		"@types/express-session": "^1.18.0",
 		"@types/jsonwebtoken": "^9.0.6",
 		"@types/node": "^20.14.10",
 		"@types/nodemailer": "^6.4.15",
+		"@types/uuid": "^10.0.0",
 		"nodemon": "^3.1.4",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.5.3"

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -1,9 +1,15 @@
 import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
+import { v4 as uuidv4 } from "uuid";
 
-import { createNewUser } from "../services/user";
+import {
+	createNewUser,
+	findUserByEmail,
+	verifyPassword,
+} from "../services/user";
 import { IRequest } from "../types";
 import { BadRequestError } from "../errors";
+import { createToken } from "../services/token";
 
 /**
  * POST /api/users/register
@@ -37,25 +43,67 @@ const register = async (req: Request, res: Response, next: NextFunction) => {
 /**
  * POST /api/users/login
  */
-const login = (req: Request, res: Response, next: NextFunction) => {
+const login = async (req: Request, res: Response, next: NextFunction) => {
 	try {
-		const refreshToken = req.cookies["refresh_token"];
+		const userAgent = req.headers["user-agent"];
+		let refreshToken = req.cookies["refresh_token"];
+
+		const { email, password } = req.body;
+
+		let userId = 0;
+		let userName = "";
 
 		// refresh 토큰 확인
 		if (!refreshToken) {
-			// TODO: refresh 토큰 및 access 토큰 발급
+			// refresh 토큰 없을 경우
+
+			// 유저 데이터 조회
+			const { id, name, passwordHash, salt } = await findUserByEmail(
+				email
+			);
+
+			userId = id;
+			userName = name;
+
+			// 로그인 검증
+			verifyPassword(password, passwordHash, salt);
+
+			// refresh 토큰 발급
+			refreshToken = createToken(
+				{ jti: uuidv4(), userId, userAgent },
+				"1w"
+			);
+
 			// TODO: 세션 생성
 		} else {
+			// refresh 토큰 있을 경우
 			// TODO: 세션 확인
-			// TODO: 세션 업데이트
-			// TODO: access 토큰 발급
+			// TODO: (세션 없을 경우) 로그인 검증 => 세션 생성
+			// TODO: (세션 있을 경우) 세션 업데이트
+			// TODO: return 리다이렉트 응답
 		}
 
-		// TODO: 쿠키 설정
+		// access 토큰 발급
+		const accessToken = createToken(
+			{
+				jti: uuidv4(),
+				userId,
+			},
+			"10m"
+		);
+
+		// 쿠키 설정
+		res.cookie("refresh_token", refreshToken, {
+			maxAge: 604800000, // 1주
+			httpOnly: true,
+			signed: true,
+		});
 
 		// 메인 페이지로 리다이렉트 응답
 		res.status(StatusCodes.SEE_OTHER).json({
 			message: "리다이렉트 실시간 채팅 메인 url",
+			access_token: accessToken,
+			user_name: userName,
 		});
 	} catch (error) {
 		next(error);

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -37,8 +37,29 @@ const register = async (req: Request, res: Response, next: NextFunction) => {
 /**
  * POST /api/users/login
  */
-const login = (req: Request, res: Response) => {
-	// TODO: 로그인
+const login = (req: Request, res: Response, next: NextFunction) => {
+	try {
+		const refreshToken = req.cookies["refresh_token"];
+
+		// refresh 토큰 확인
+		if (!refreshToken) {
+			// TODO: refresh 토큰 및 access 토큰 발급
+			// TODO: 세션 생성
+		} else {
+			// TODO: 세션 확인
+			// TODO: 세션 업데이트
+			// TODO: access 토큰 발급
+		}
+
+		// TODO: 쿠키 설정
+
+		// 메인 페이지로 리다이렉트 응답
+		res.status(StatusCodes.SEE_OTHER).json({
+			message: "리다이렉트 실시간 채팅 메인 url",
+		});
+	} catch (error) {
+		next(error);
+	}
 };
 
 export { register, login };

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -9,10 +9,11 @@ import { BadRequestError } from "../errors";
  * POST /api/users/register
  */
 const register = async (req: Request, res: Response, next: NextFunction) => {
-	const { email, verified } = (req as IRequest).tokenDecodedInfo;
-	const { password, name } = req.body;
-
 	try {
+		const { email, verified } = (req as IRequest).tokenDecodedInfos!
+			.authInfo!;
+		const { password, name } = req.body;
+
 		// 인증 확인
 		if (!verified) {
 			throw new BadRequestError("이메일 인증이 이뤄지지 않았습니다.");

--- a/server/src/db/context/users.ts
+++ b/server/src/db/context/users.ts
@@ -1,32 +1,206 @@
-import { RowDataPacket } from "mysql2";
-import { connectDB } from "../connection";
-import { TUsersSchema } from "../../types";
+import { ResultSetHeader, RowDataPacket } from "mysql2";
 
-const insertUser = async (
-	email: string,
-	name: string,
-	passwordHash: string,
-	salt: string
-) => {
+import { connectDB } from "../connection";
+import { IUserDTO, IUserSessionDTO } from "../../types";
+
+/**
+ * 새로운 유저 저장
+ */
+const insertUser = async (userDTO: IUserDTO): Promise<IUserDTO> => {
+	const user = { ...userDTO };
+
 	const connection = await connectDB();
-	const result = await connection.query(
+	const [result] = await connection.query<ResultSetHeader>(
 		`INSERT INTO users
-        (email, name, salt, password_hash) VALUES (?, ?, ?, ?)`,
-		[email, name, passwordHash, salt]
+        (email, name, password_hash, salt) VALUES (?, ?, ?, ?)`,
+		[user.email, user.name, user.passwordHash, user.salt]
+	);
+
+	user.id = result.insertId;
+
+	return user;
+};
+
+/**
+ * 유저 세션에 저장
+ */
+const insertUserSession = async (
+	userSessionDTO: IUserSessionDTO
+): Promise<ResultSetHeader> => {
+	const connection = await connectDB();
+	const [result] = await connection.query<ResultSetHeader>(
+		`INSERT INTO user_sessions
+        (client_id, user_id, user_agent, ip_address, refresh_token, expired_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		[
+			userSessionDTO.clientId,
+			userSessionDTO.userId,
+			userSessionDTO.userAgent,
+			userSessionDTO.ipAddress,
+			userSessionDTO.refreshToken,
+			userSessionDTO.expiredAt,
+		]
 	);
 
 	return result;
 };
 
-const getUserByEmail = async (email: string): Promise<TUsersSchema[]> => {
+/**
+ * 유저 조회 by id
+ */
+const getUserById = async (userDTO: IUserDTO): Promise<IUserDTO[]> => {
 	const connection = await connectDB();
 	const [rows] = await connection.query<RowDataPacket[]>(
-		`SELECT id, name, password_hash, salt FROM users
-        WHERE email=?`,
-		[email]
+		`SELECT * FROM users
+        WHERE id=?`,
+		[userDTO.id]
 	);
 
-	return rows as TUsersSchema[];
+	return rows.map(
+		(row: RowDataPacket) =>
+			({
+				email: row.email,
+				password: userDTO.password,
+				id: row.id,
+				name: row.name,
+				passwordHash: row.password_hash,
+				salt: row.salt,
+				createdAt: row.created_at,
+				updatedAt: row.updated_at,
+			} as IUserDTO)
+	);
 };
 
-export { insertUser, getUserByEmail };
+/**
+ * 유저 조회 by email
+ */
+const getUserByEmail = async (userDTO: IUserDTO): Promise<IUserDTO[]> => {
+	const connection = await connectDB();
+	const [rows] = await connection.query<RowDataPacket[]>(
+		`SELECT * FROM users
+        WHERE email=?`,
+		[userDTO.email]
+	);
+
+	return rows.map(
+		(row: RowDataPacket) =>
+			({
+				email: row.email,
+				password: userDTO.password,
+				id: row.id,
+				name: row.name,
+				passwordHash: row.password_hash,
+				salt: row.salt,
+				createdAt: row.created_at,
+				updatedAt: row.updated_at,
+			} as IUserDTO)
+	);
+};
+
+/**
+ * 유저 세션 조회
+ */
+const getUserSessionAndUserName = async (
+	userSessionDTO: IUserSessionDTO
+): Promise<IUserSessionDTO[]> => {
+	const connection = await connectDB();
+	const [rows] = await connection.query<RowDataPacket[]>(
+		`
+		SELECT us.*, u.name AS user_name
+		FROM user_sessions us
+		JOIN users u ON us.user_id = u.id
+		WHERE us.client_id = ?
+		OR (us.user_id = ? AND us.user_agent = ? AND us.ip_address = ?);
+		`,
+		[
+			userSessionDTO.clientId,
+			userSessionDTO.userId,
+			userSessionDTO.userAgent,
+			userSessionDTO.ipAddress,
+		]
+	);
+
+	return rows.map(
+		(row: RowDataPacket) =>
+			({
+				id: row.id,
+				clientId: row.client_id,
+				userId: row.user_id,
+				userName: row.user_name,
+				userAgent: row.user_agent,
+				ipAddress: row.ip_address,
+				refreshToken: row.refresh_token,
+				revoked: row.revoked,
+				expiredAt: row.expired_at,
+				cretedAt: row.created_at,
+				updatedAt: row.updated_at,
+				lastAccessedAt: row.last_accessed_at,
+			} as IUserSessionDTO)
+	);
+};
+
+/**
+ * 유저 세션 정보 업데이트
+ */
+const updateUserSession = async (
+	userSessionDTO: IUserSessionDTO
+): Promise<ResultSetHeader> => {
+	const connection = await connectDB();
+	const [result] = await connection.query<ResultSetHeader>(
+		`
+		UPDATE user_sessions
+		SET refresh_token=?, revoked=?, expired_at=?, updated_at=?, last_accessed_at=?
+		WHERE client_id = ?
+		OR (user_id = ? AND user_agent = ? AND ip_address = ?);
+		`,
+		[
+			userSessionDTO.refreshToken,
+			userSessionDTO.revoked,
+			userSessionDTO.expiredAt,
+			userSessionDTO.updatedAt,
+			userSessionDTO.lastAccessedAt,
+			userSessionDTO.clientId,
+			userSessionDTO.userId,
+			userSessionDTO.userAgent,
+			userSessionDTO.ipAddress,
+		]
+	);
+
+	return result;
+};
+
+/**
+ * 유저 revoked 업데이트
+ */
+const updateUserSessionRevoked = async (
+	userSessionDTO: IUserSessionDTO
+): Promise<ResultSetHeader> => {
+	const connection = await connectDB();
+	const [result] = await connection.query<ResultSetHeader>(
+		`
+		UPDATE user_sessions
+		SET revoked = ?, updated_at = ?, last_accessed_at = ?
+		WHERE client_id = ? OR (user_id = ? AND user_agent = ? AND ip_address = ?);
+		`,
+		[
+			userSessionDTO.revoked,
+			userSessionDTO.updatedAt,
+			userSessionDTO.lastAccessedAt,
+			userSessionDTO.clientId,
+			userSessionDTO.userId,
+			userSessionDTO.userAgent,
+			userSessionDTO.ipAddress,
+		]
+	);
+
+	return result;
+};
+
+export {
+	insertUser,
+	insertUserSession,
+	getUserById,
+	getUserByEmail,
+	getUserSessionAndUserName,
+	updateUserSession,
+	updateUserSessionRevoked,
+};

--- a/server/src/db/context/users.ts
+++ b/server/src/db/context/users.ts
@@ -1,4 +1,6 @@
+import { RowDataPacket } from "mysql2";
 import { connectDB } from "../connection";
+import { TUsersSchema } from "../../types";
 
 const insertUser = async (
 	email: string,
@@ -16,4 +18,15 @@ const insertUser = async (
 	return result;
 };
 
-export { insertUser };
+const getUserByEmail = async (email: string): Promise<TUsersSchema[]> => {
+	const connection = await connectDB();
+	const [rows] = await connection.query<RowDataPacket[]>(
+		`SELECT id, name, password_hash, salt FROM users
+        WHERE email=?`,
+		[email]
+	);
+
+	return rows as TUsersSchema[];
+};
+
+export { insertUser, getUserByEmail };

--- a/server/src/db/context/verifications.ts
+++ b/server/src/db/context/verifications.ts
@@ -3,11 +3,11 @@ import { connectDB } from "../connection";
 /**
  * 인증 번호 생성
  */
-const insertVerification = async (code: string) => {
+const insertVerification = async (jti: string, code: string) => {
 	const connection = await connectDB();
 	const result = await connection.query(
-		`INSERT INTO verifications (code, expired_at) VALUES (?, ?)`,
-		[code, new Date(Date.now() + 300000)]
+		`INSERT INTO verifications (jti, code, expired_at) VALUES (?, ?, ?)`,
+		[jti, code, new Date(Date.now() + 300000)]
 	);
 
 	return result;
@@ -16,11 +16,11 @@ const insertVerification = async (code: string) => {
 /**
  * 인증 코드 조회
  */
-const getCodeById = async (id: number) => {
+const getCodeByJti = async (jti: string) => {
 	const connection = await connectDB();
 	const [rows] = await connection.query(
 		`SELECT code FROM verifications WHERE id=?`,
-		[id]
+		[jti]
 	);
 
 	return rows;
@@ -29,15 +29,15 @@ const getCodeById = async (id: number) => {
 /**
  * 인증 번호 수정
  */
-const updateVerification = async (id: number, code: string) => {
+const updateVerification = async (jti: string, code: string) => {
 	const connection = await connectDB();
 	const result = await connection.query(
 		`
 		UPDATE verifications
 		SET code=?
-		WHERE id=?
+		WHERE jti=?
 		`,
-		[code, id]
+		[code, jti]
 	);
 
 	return result;
@@ -46,14 +46,14 @@ const updateVerification = async (id: number, code: string) => {
 /**
  * 인증 번호 삭제
  */
-const deleteVerification = async (id: number) => {
+const deleteVerification = async (jti: string) => {
 	const connection = await connectDB();
 	const [result] = await connection.query(
 		`
 		DELETE FROM verifications
-		WHERE id=?
+		WHERE jti=?
 		`,
-		[id]
+		[jti]
 	);
 
 	return result;
@@ -61,7 +61,7 @@ const deleteVerification = async (id: number) => {
 
 export {
 	insertVerification,
-	getCodeById,
+	getCodeByJti,
 	updateVerification,
 	deleteVerification,
 };

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -1,69 +1,28 @@
 import { NextFunction, Request, Response } from "express";
-import { TokenExpiredError } from "jsonwebtoken";
 
+import { IRequest, ITokenDTO } from "../types";
 import {
-	IAccessInfo,
-	IAuthInfo,
-	IRefreshInfo,
-	IRequest,
-	TTokenDocodedInfos,
-} from "../types";
-
-import { BadRequestError, UnauthorizedError } from "../errors";
-
-import { verifyToken } from "../services/token";
+	checkTokenExpiration,
+	createToken,
+	verifyAuthToken,
+	verifyLoginToken,
+} from "../services/token";
+import { UnauthorizedError } from "../errors";
+import { findUserSession, revokeUserSession } from "../services/user";
+import { generateExp } from "../utils/time";
 
 /**
- * 다수의 토큰 검증
+ * register 토큰 검증
  */
-const verifyTokens = (...tokenNames: string[]) => {
-	return (req: Request, _: Response, next: NextFunction) => {
-		try {
-			for (const tokenName of tokenNames) {
-				// 토큰 조회
-				const token = req.cookies[tokenName];
-
-				// 토큰 검증
-				const decoded = verifyToken(token);
-
-				// req에 쿠키에 담긴 토큰 payload를 담은 토큰 객체 생성
-				const tokenDecodedInfos: TTokenDocodedInfos = {};
-				(req as IRequest).tokenDecodedInfos = tokenDecodedInfos;
-
-				// 다음 미들웨어로 전달
-				switch (tokenName) {
-					case "auth_token":
-						tokenDecodedInfos.authInfo = decoded as IAuthInfo;
-						break;
-					case "access_token":
-						tokenDecodedInfos.accessInfo = decoded as IAccessInfo;
-						break;
-					case "refresh_token":
-						tokenDecodedInfos.refreshInfo = decoded as IRefreshInfo;
-						break;
-					default:
-						throw new BadRequestError(
-							"토큰 이름이 잘못되었습니다."
-						);
-				}
-			}
-
-			next();
-		} catch (error) {
-			// 토큰 만료
-			if (error instanceof TokenExpiredError) {
-				error = new UnauthorizedError();
-			}
-
-			next(error);
-		}
-	};
-};
-
-const authUser = (req: Request, _: Response, next: NextFunction) => {
+const authRegister = (req: Request, _: Response, next: NextFunction) => {
 	try {
-		const accessInfo = (req as IRequest).tokenDecodedInfos!.accessInfo!;
-		const refreshInfo = (req as IRequest).tokenDecodedInfos!.refreshInfo!;
+		// 이메일 인증 토큰
+		const authToken = req.cookies.authToken;
+
+		// 토큰 유효성 검사
+		(req as IRequest).authToken = verifyAuthToken({
+			token: authToken,
+		} as const);
 
 		next();
 	} catch (error) {
@@ -71,4 +30,123 @@ const authUser = (req: Request, _: Response, next: NextFunction) => {
 	}
 };
 
-export { verifyTokens, authUser };
+/**
+ * auth(refresh, access) 검증
+ */
+const authLiveChat = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		// access, refresh 토큰
+		const accessToken = req.cookies.accessToken;
+		const refreshToken = req.cookies.refreshToken;
+
+		// 토큰 유무
+		const isAccessToken = !!accessToken;
+		const isRefreshToken = !!refreshToken;
+
+		// 토큰이 둘 다 없을 경우
+		if (!isAccessToken && !isRefreshToken) {
+			throw new UnauthorizedError("토큰이 제공되지 않았습니다.");
+		}
+
+		// 토큰 유효성 검사
+		const accessTokenDTO: ITokenDTO = ((req as IRequest).accessToken =
+			isAccessToken
+				? verifyLoginToken({
+						token: accessToken,
+				  })
+				: {});
+		const refreshTokenDTO: ITokenDTO = ((req as IRequest).refreshToken =
+			isRefreshToken ? verifyLoginToken({ token: refreshToken }) : {});
+
+		// 토큰 만료시간 검사
+		const isAccessTokenExpired = isAccessToken
+			? checkTokenExpiration(accessTokenDTO)
+			: true;
+		const isRefreshTokenExpired = isRefreshToken
+			? checkTokenExpiration(refreshTokenDTO)
+			: true;
+
+		// 세션 조회
+		const userSession = await findUserSession({
+			userId: isAccessToken
+				? parseInt(accessTokenDTO.payload!.sub!)
+				: undefined,
+			clientId: isRefreshToken
+				? refreshTokenDTO.payload!.clientId
+				: undefined,
+			userAgent: req.headers["user-agent"],
+			ipAddress: req.ip,
+		});
+
+		// 세션이 없을 때
+		if (!userSession) {
+			res.clearCookie("refreshToken");
+			res.clearCookie("accessToken");
+			throw new UnauthorizedError("세션이 없습니다.");
+		}
+
+		if (isAccessTokenExpired && isRefreshTokenExpired) {
+			// case1: 둘다 만료
+
+			await revokeUserSession(userSession);
+
+			res.clearCookie("refreshToken");
+			res.clearCookie("accessToken");
+
+			throw new UnauthorizedError("세션 만료");
+		} else if (isAccessTokenExpired) {
+			// case2: access 만료
+
+			// access 토큰 발급
+			const nextAccessTokenDTO = createToken({
+				payload: {
+					// exp: generateExp(10 * 60), // 10분
+					exp: generateExp(10), // 10초
+					sub: `${userSession.userId}`,
+				},
+			});
+
+			// access 토큰 쿠키 설정
+			res.cookie("accessToken", nextAccessTokenDTO.token, {
+				// maxAge: 10 * 60 * 1000, // 10분
+				maxAge: 1 * 60 * 60 * 1000, // 1시간
+				httpOnly: true,
+				signed: true,
+			});
+
+			(req as IRequest).accessToken = nextAccessTokenDTO;
+		} else if (isRefreshTokenExpired) {
+			// case3: refresh 만료
+
+			// refresh 토큰 발급
+			const nextRefreshTokenDTO = createToken({
+				payload: {
+					clientId: userSession.clientId,
+					// exp: generateExp(7 * 24 * 60 * 60), // 1주
+					exp: generateExp(20), // 20초
+					aud: userSession.userAgent, // 클라이언트 정보
+				},
+			});
+
+			// refresh 토큰 쿠키 설정
+			res.cookie("refreshToken", nextRefreshTokenDTO.token, {
+				// maxAge: 7 * 24 * 60 * 60 * 1000, // 1주
+				maxAge: 1 * 60 * 60 * 1000, // 1시간
+				httpOnly: true,
+				signed: true,
+			});
+
+			(req as IRequest).refreshToken = nextRefreshTokenDTO;
+		}
+
+		next();
+	} catch (error) {
+		next(error);
+	}
+};
+
+export { authRegister, authLiveChat };

--- a/server/src/middlewares/validate.ts
+++ b/server/src/middlewares/validate.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
 import { StatusCodes } from "http-status-codes";
+import { BadRequestError } from "../errors";
 
 /**
  * HTTP Requests 유효성 검사
@@ -27,13 +28,19 @@ const mergeSignedCookiesIntoCookies = (
 	const signedCookies = req.signedCookies;
 	const cookies = req.cookies;
 
-	for (const key of Object.keys(signedCookies)) {
-		if (!!cookies.key) continue;
+	try {
+		for (const key of Object.keys(signedCookies)) {
+			if (!!cookies.key) {
+				throw new BadRequestError("서명되지 않은 쿠키가 있습니다.");
+			}
 
-		cookies[key] = signedCookies[key];
+			cookies[key] = signedCookies[key];
+		}
+
+		next();
+	} catch (error) {
+		next(error);
 	}
-
-	next();
 };
 
 export { validate, mergeSignedCookiesIntoCookies };

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { checkSchema } from "express-validator";
+import { checkExact, checkSchema } from "express-validator";
 
 import {
 	createVerification,
@@ -18,7 +18,7 @@ import {
 	mergeSignedCookiesIntoCookies,
 	validate,
 } from "../middlewares/validate";
-import { verifyTokens } from "../middlewares/auth";
+import { authRegister } from "../middlewares/auth";
 
 const router = express.Router();
 
@@ -32,7 +32,9 @@ router.use(express.json());
  */
 router.post(
 	"/email/verification",
+	mergeSignedCookiesIntoCookies,
 	checkSchema(emailSchema),
+	checkExact(),
 	validate,
 	createVerification
 );
@@ -40,16 +42,18 @@ router.patch(
 	"/email/verification",
 	mergeSignedCookiesIntoCookies,
 	checkSchema(cookieJWTSchema),
+	checkExact(),
 	validate,
-	verifyTokens("auth_token"),
+	authRegister,
 	updateVerification
 );
 router.delete(
 	"/email/verification",
 	mergeSignedCookiesIntoCookies,
 	checkSchema(cookieJWTSchema),
+	checkExact(),
 	validate,
-	verifyTokens("auth_token"),
+	authRegister,
 	deleteVerification
 );
 
@@ -60,8 +64,9 @@ router.post(
 	"/email/send-verification",
 	mergeSignedCookiesIntoCookies,
 	checkSchema(cookieJWTSchema),
+	checkExact(),
 	validate,
-	verifyTokens("auth_token"),
+	authRegister,
 	sendVerification
 );
 
@@ -72,8 +77,9 @@ router.post(
 	"/email/verify",
 	mergeSignedCookiesIntoCookies,
 	checkSchema(verifySchema),
+	checkExact(),
 	validate,
-	verifyTokens("auth_token"),
+	authRegister,
 	verify
 );
 

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { checkSchema } from "express-validator";
+import { checkExact, checkSchema } from "express-validator";
 
 import { register, login } from "../controllers/user.controller";
 import {
@@ -7,7 +7,8 @@ import {
 	validate,
 } from "../middlewares/validate";
 import { loginSchema, registerSchema } from "../validations/user.validation";
-import { verifyTokens } from "../middlewares/auth";
+import { authRegister, authLiveChat } from "../middlewares/auth";
+import { IRequest } from "../types";
 
 const router = express.Router();
 router.use(express.json());
@@ -19,16 +20,29 @@ router.post(
 	"/register",
 	mergeSignedCookiesIntoCookies,
 	checkSchema(registerSchema),
+	checkExact(),
 	validate,
-	verifyTokens("auth_token"),
+	authRegister,
 	register
 );
 router.post(
 	"/login",
 	mergeSignedCookiesIntoCookies,
 	checkSchema(loginSchema),
+	checkExact(),
 	validate,
 	login
+);
+router.post(
+	"/test",
+	mergeSignedCookiesIntoCookies,
+	authLiveChat,
+	(req, res) => {
+		res.status(200).json({
+			accessToken: (req as IRequest).accessToken,
+			refreshToken: (req as IRequest).refreshToken,
+		});
+	}
 );
 
 export default router;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -6,7 +6,7 @@ import {
 	mergeSignedCookiesIntoCookies,
 	validate,
 } from "../middlewares/validate";
-import { registerSchema } from "../validations/user.validation";
+import { loginSchema, registerSchema } from "../validations/user.validation";
 import { verifyTokens } from "../middlewares/auth";
 
 const router = express.Router();
@@ -23,6 +23,12 @@ router.post(
 	verifyTokens("auth_token"),
 	register
 );
-router.post("/login", login);
+router.post(
+	"/login",
+	mergeSignedCookiesIntoCookies,
+	checkSchema(loginSchema),
+	validate,
+	login
+);
 
 export default router;

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -1,75 +1,134 @@
-import { ResultSetHeader } from "mysql2";
-import { v4 as uuidv4 } from "uuid";
 import dotenv from "dotenv";
 
 import {
 	insertVerification,
 	deleteVerification,
-	updateVerification,
+	updateVerificationCode,
 	getCodeByJti,
 } from "../db/context/verifications";
 import { createRandomNumber } from "../utils/random";
-import { TVerificationsShema } from "../types";
+import { BadRequestError, UnauthorizedError } from "../errors";
+import { ITokenDTO, IVerificationDTO } from "../types";
+import { createToken } from "./token";
 
 dotenv.config();
 
 /**
- * 새로운 인증 번호 생성
+ * 새로운 인증 번호 생성하고 토큰 발급
  */
-const createNewVerification = async (): Promise<string> => {
-	const code = createRandomNumber(6);
-	const jti = uuidv4();
-	await insertVerification(jti, code);
+const generateVerification = async (
+	verificationDTO: IVerificationDTO
+): Promise<IVerificationDTO> => {
+	const verification = {
+		...verificationDTO,
+		authToken: {
+			...verificationDTO.authToken,
+			payload: { ...verificationDTO.authToken?.payload },
+		} as ITokenDTO,
+	};
 
-	return jti;
+	// 코드 생성
+	verification.code = createRandomNumber(6);
+
+	// 토큰 발급
+	verification.authToken = createToken({
+		...verification.authToken,
+	} as const);
+
+	// 결과 에러 핸들링
+	const result = await insertVerification(verification);
+
+	if (result.affectedRows !== 1) throw new Error("");
+
+	return verification;
 };
 
 /**
  * 인증 코드 조회
  */
-const findCodeByJti = async (jti: string): Promise<object> => {
-	const result = await getCodeByJti(jti);
+const findVerification = async (
+	verificationDTO: IVerificationDTO
+): Promise<IVerificationDTO> => {
+	const verification = {
+		...verificationDTO,
+		authToken: {
+			...verificationDTO.authToken,
+			payload: { ...verificationDTO.authToken?.payload },
+		} as ITokenDTO,
+	};
 
-	return result;
+	const rows = await getCodeByJti(verificationDTO);
+
+	if (rows.length === 0) {
+		throw new BadRequestError("없는 코드 입니다.");
+	}
+
+	verification.code = rows[0].code;
+
+	return verification;
 };
 
 /**
- * 존재하는 인증 번호 수정
+ * 인증 번호 수정
  */
-const updateCodeByJti = async (jti: string): Promise<ResultSetHeader> => {
-	const code = createRandomNumber(6);
-	const [result] = await updateVerification(jti, code);
+const changeCode = async (verificationDTO: IVerificationDTO): Promise<void> => {
+	const verification = {
+		...verificationDTO,
+		token: {
+			...verificationDTO.authToken,
+			payload: { ...verificationDTO.authToken?.payload },
+		} as ITokenDTO,
+	};
 
-	return result as ResultSetHeader;
+	verification.code = createRandomNumber(6);
+	const result = await updateVerificationCode(verification);
+
+	if (result.affectedRows !== 1) throw new Error();
 };
 
 /**
- * 이메일로 찾은 인증 번호 삭제
+ * 이메일 인증 정보 삭제
  */
-const removeVerificationByJti = async (
-	jti: string
-): Promise<ResultSetHeader> => {
-	const result = await deleteVerification(jti);
+const removeVerification = async (
+	verificationDTO: IVerificationDTO
+): Promise<void> => {
+	const result = await deleteVerification(verificationDTO);
 
-	return result as ResultSetHeader;
+	if (result.affectedRows !== 1) throw new Error();
 };
 
 /**
  * 인증 번호 조회 및 검증
  */
-const verifyCode = async (jti: string, reqCode: string): Promise<boolean> => {
-	const [{ code }] = (await getCodeByJti(jti)) as Array<TVerificationsShema>;
+const verifyCode = async (verificationDTO: IVerificationDTO): Promise<void> => {
+	const rows = await getCodeByJti(verificationDTO);
+
+	if (rows.length !== 1) throw new Error("");
+
+	const code = rows[0].code;
 
 	// 검증
-	const isVerify = reqCode === code ? true : false;
+	const isVerify = verificationDTO.code! === code ? true : false;
 
-	return isVerify;
+	if (!isVerify) throw new UnauthorizedError("잘못된 코드입니다.");
+};
+
+/**
+ * 이메일 인증 확인
+ */
+const checkVerifyEmail = (tokenDTO: ITokenDTO, verified: boolean): void => {
+	if (tokenDTO.payload!.verified !== verified) {
+		if (verified)
+			throw new BadRequestError("이메일 인증이 이뤄지지 않았습니다.");
+		else throw new BadRequestError("이미 인증되었습니다.");
+	}
 };
 
 export {
-	createNewVerification,
-	findCodeByJti,
-	updateCodeByJti,
-	removeVerificationByJti,
+	generateVerification,
+	findVerification,
+	changeCode,
+	removeVerification,
 	verifyCode,
+	checkVerifyEmail,
 };

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -1,13 +1,14 @@
-import { QueryResult, ResultSetHeader } from "mysql2";
+import { ResultSetHeader } from "mysql2";
+import { v4 as uuidv4 } from "uuid";
 import dotenv from "dotenv";
 
-import { createRandomNumber } from "../utils/random";
 import {
 	insertVerification,
 	deleteVerification,
 	updateVerification,
-	getCodeById,
+	getCodeByJti,
 } from "../db/context/verifications";
+import { createRandomNumber } from "../utils/random";
 import { TVerificationsShema } from "../types";
 
 dotenv.config();
@@ -15,18 +16,19 @@ dotenv.config();
 /**
  * 새로운 인증 번호 생성
  */
-const createNewVerification = async (): Promise<ResultSetHeader> => {
+const createNewVerification = async (): Promise<string> => {
 	const code = createRandomNumber(6);
-	const [result] = await insertVerification(code);
+	const jti = uuidv4();
+	await insertVerification(jti, code);
 
-	return result as ResultSetHeader;
+	return jti;
 };
 
 /**
  * 인증 코드 조회
  */
-const findCodeById = async (id: number): Promise<object> => {
-	const result = await getCodeById(id);
+const findCodeByJti = async (jti: string): Promise<object> => {
+	const result = await getCodeByJti(jti);
 
 	return result;
 };
@@ -34,9 +36,9 @@ const findCodeById = async (id: number): Promise<object> => {
 /**
  * 존재하는 인증 번호 수정
  */
-const updateCodeById = async (id: number): Promise<ResultSetHeader> => {
+const updateCodeByJti = async (jti: string): Promise<ResultSetHeader> => {
 	const code = createRandomNumber(6);
-	const [result] = await updateVerification(id, code);
+	const [result] = await updateVerification(jti, code);
 
 	return result as ResultSetHeader;
 };
@@ -44,8 +46,10 @@ const updateCodeById = async (id: number): Promise<ResultSetHeader> => {
 /**
  * 이메일로 찾은 인증 번호 삭제
  */
-const removeVerificationById = async (id: number): Promise<ResultSetHeader> => {
-	const result = await deleteVerification(id);
+const removeVerificationByJti = async (
+	jti: string
+): Promise<ResultSetHeader> => {
+	const result = await deleteVerification(jti);
 
 	return result as ResultSetHeader;
 };
@@ -53,8 +57,8 @@ const removeVerificationById = async (id: number): Promise<ResultSetHeader> => {
 /**
  * 인증 번호 조회 및 검증
  */
-const verifyCode = async (id: number, reqCode: string): Promise<boolean> => {
-	const [{ code }] = (await getCodeById(id)) as Array<TVerificationsShema>;
+const verifyCode = async (jti: string, reqCode: string): Promise<boolean> => {
+	const [{ code }] = (await getCodeByJti(jti)) as Array<TVerificationsShema>;
 
 	// 검증
 	const isVerify = reqCode === code ? true : false;
@@ -64,8 +68,8 @@ const verifyCode = async (id: number, reqCode: string): Promise<boolean> => {
 
 export {
 	createNewVerification,
-	findCodeById,
-	updateCodeById,
-	removeVerificationById,
+	findCodeByJti,
+	updateCodeByJti,
+	removeVerificationByJti,
 	verifyCode,
 };

--- a/server/src/services/token.ts
+++ b/server/src/services/token.ts
@@ -1,17 +1,17 @@
 import jwt from "jsonwebtoken";
 import dotenv from "dotenv";
 
-import { IAuthTokenPayload } from "../types";
+import { IAccessInfo, IAuthInfo, IRefreshInfo } from "../types";
 
 dotenv.config();
+
+type TPayload = IAuthInfo | IAccessInfo | IRefreshInfo;
+type TExpiresIn = string | number | undefined;
 
 /**
  * 토큰 발급
  */
-const createToken = (
-	payload: IAuthTokenPayload,
-	expiresIn: string | number | undefined
-) => {
+const createToken = (payload: TPayload, expiresIn: TExpiresIn): string => {
 	const token = jwt.sign(payload, process.env.JWT_SECRET_KEY!, {
 		issuer: process.env.JWT_ISSUER,
 		expiresIn,
@@ -23,11 +23,8 @@ const createToken = (
 /**
  * 토큰 검증
  */
-const verifyToken = (token: string): IAuthTokenPayload => {
-	const decoded = jwt.verify(
-		token,
-		process.env.JWT_SECRET_KEY!
-	) as IAuthTokenPayload;
+const verifyToken = (token: string): TPayload => {
+	const decoded = jwt.verify(token, process.env.JWT_SECRET_KEY!) as TPayload;
 
 	return decoded;
 };

--- a/server/src/services/token.ts
+++ b/server/src/services/token.ts
@@ -1,32 +1,112 @@
-import jwt from "jsonwebtoken";
+import jwt, {
+	JsonWebTokenError,
+	JwtPayload,
+	TokenExpiredError,
+} from "jsonwebtoken";
+import { v4 as uuidv4 } from "uuid";
 import dotenv from "dotenv";
 
-import { IAccessInfo, IAuthInfo, IRefreshInfo } from "../types";
+import { ITokenDTO } from "../types";
+import { UnauthorizedError } from "../errors";
 
 dotenv.config();
 
-type TPayload = IAuthInfo | IAccessInfo | IRefreshInfo;
-type TExpiresIn = string | number | undefined;
-
 /**
- * 토큰 발급
+ * 토큰 생성
  */
-const createToken = (payload: TPayload, expiresIn: TExpiresIn): string => {
-	const token = jwt.sign(payload, process.env.JWT_SECRET_KEY!, {
-		issuer: process.env.JWT_ISSUER,
-		expiresIn,
-	});
+const createToken = (tokenDTO: ITokenDTO): ITokenDTO => {
+	const token = {
+		...tokenDTO,
+		payload: { ...tokenDTO.payload },
+	} as ITokenDTO;
+
+	// 토큰 값 설정
+	token.secretKey = process.env.JWT_SECRET_KEY;
+	token.payload!.jti = uuidv4();
+	token.payload!.iss = process.env.JWT_ISSUER;
+
+	token.token = jwt.sign(token.payload!, token.secretKey!);
 
 	return token;
 };
 
 /**
- * 토큰 검증
+ * auth 토큰 검증
  */
-const verifyToken = (token: string): TPayload => {
-	const decoded = jwt.verify(token, process.env.JWT_SECRET_KEY!) as TPayload;
+const verifyAuthToken = (tokenDTO: ITokenDTO): ITokenDTO => {
+	const token = {
+		...tokenDTO,
+		payload: { ...tokenDTO.payload },
+	} as ITokenDTO;
 
-	return decoded;
+	try {
+		token.secretKey = process.env.JWT_SECRET_KEY;
+		token.payload = jwt.verify(
+			token.token!,
+			token.secretKey!
+		) as JwtPayload;
+
+		return token;
+	} catch (error) {
+		if (error instanceof JsonWebTokenError) {
+			throw new UnauthorizedError("유효한 토큰이 아닙니다.");
+		}
+
+		if (error instanceof TokenExpiredError) {
+			throw new UnauthorizedError(
+				"인증이 만료되었습니다. 다시 시도해주세요."
+			);
+		}
+
+		throw new Error("auth 토큰 검증 중 에러");
+	}
 };
 
-export { createToken, verifyToken };
+/**
+ * 로그인 관련 토큰 검증
+ */
+const verifyLoginToken = (tokenDTO: ITokenDTO): ITokenDTO => {
+	const token = { ...tokenDTO };
+
+	if (!token.token) {
+		throw new UnauthorizedError("토큰이 제공되지 않았습니다.");
+	}
+
+	token.secretKey = process.env.JWT_SECRET_KEY;
+
+	try {
+		token.payload = jwt.verify(
+			token.token!,
+			token.secretKey!
+		) as JwtPayload;
+
+		return token;
+	} catch (error) {
+		if (error instanceof JsonWebTokenError) {
+			if (error.message === "invalid signature") {
+				throw new UnauthorizedError("유효한 토큰이 아닙니다.");
+			}
+			if (error.message === "jwt malformed") {
+				throw new UnauthorizedError("잘못된 토큰입니다.");
+			}
+		}
+
+		if (error instanceof TokenExpiredError) {
+			token.payload = jwt.decode(token.token!) as JwtPayload;
+
+			return token;
+		}
+
+		throw new Error("인증 에러");
+	}
+};
+
+/**
+ * 토큰 만료 시간 검사
+ */
+const checkTokenExpiration = (token: ITokenDTO): boolean => {
+	const now = Date.now();
+	return token.payload!.exp! * 1000 < now;
+};
+
+export { createToken, verifyAuthToken, verifyLoginToken, checkTokenExpiration };

--- a/server/src/services/user.ts
+++ b/server/src/services/user.ts
@@ -1,9 +1,20 @@
 import dotenv from "dotenv";
 import { randomBytes, pbkdf2Sync } from "crypto";
 
-import { insertUser } from "../db/context/users";
+import { getUserByEmail, insertUser } from "../db/context/users";
+import { BadRequestError } from "../errors";
 
 dotenv.config();
+
+/**
+ * 타입 정의
+ */
+type TUserInfo = {
+	id: number;
+	name: string;
+	passwordHash: string;
+	salt: string;
+};
 
 /**
  * 유저 생성
@@ -27,4 +38,40 @@ const createNewUser = async (
 	return result;
 };
 
-export { createNewUser };
+const findUserByEmail = async (email: string): Promise<TUserInfo> => {
+	const result = await getUserByEmail(email);
+
+	console.log(result);
+
+	if (result.length > 1) throw new Error("검색된 유저의 수가 너무 많습니다.");
+	if (result.length < 1) throw new BadRequestError("유저 정보가 없습니다.");
+
+	const userInfo: TUserInfo = {
+		id: result[0].id,
+		name: result[0].name,
+		passwordHash: result[0].password_hash,
+		salt: result[0].salt,
+	};
+
+	return userInfo;
+};
+
+const verifyPassword = (
+	password: string,
+	passwordHash: string,
+	salt: string
+): void => {
+	const reqPasswordHash = pbkdf2Sync(
+		password,
+		salt,
+		10000,
+		10,
+		"sha512"
+	).toString("base64");
+
+	const isVerify = reqPasswordHash === passwordHash;
+
+	if (!isVerify) throw new BadRequestError("비밀번호가 틀립니다.");
+};
+
+export { createNewUser, findUserByEmail, verifyPassword };

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -1,61 +1,77 @@
 import { Request } from "express";
 import { JwtPayload, SignOptions } from "jsonwebtoken";
+import { RowDataPacket } from "mysql2";
 
 /**
- * DB 관련 타입 및 인터페이스
+ * express 관련 타입 및 인터페이스
  */
-
-// verifications 스키마
-type TVerificationsShema = {
-	id: number;
-	email: string;
-	code: string;
-	expired_at: Date;
-	created_at: Date;
-	updated_at: Date;
-};
-
-// users 스키마
-type TUsersSchema = {
-	id: number;
-	email: string;
-	name: string;
-	password_hash: string;
-	salt: string;
-	creted_at: Date;
-	updated_at: Date;
-};
-
-/**
- * 토큰 관련 타입 및 인터페이스
- */
-
-type TTokenDocodedInfos = {
-	authInfo?: IAuthInfo;
-	accessInfo?: IAccessInfo;
-	refreshInfo?: IRefreshInfo;
-};
 
 interface IRequest extends Request {
-	tokenDecodedInfos?: TTokenDocodedInfos;
+	authToken?: ITokenDTO;
+	accessToken?: ITokenDTO;
+	refreshToken?: ITokenDTO;
+	verification?: IVerificationDTO;
+	user?: IUserDTO;
+	userSession?: IUserSessionDTO;
 }
 
-interface IJwtPayload extends JwtPayload {
-	jti: string;
+/**
+ * DTO 타입 및 인터페이스
+ */
+
+// 이메일 인증 DTO
+interface IVerificationDTO {
+	id?: number;
+	code?: string;
+	authToken?: ITokenDTO;
+	expiredAt?: Date;
+	createdAt?: Date;
+	updatedAt?: Date;
 }
 
-interface IAuthInfo extends IJwtPayload {
-	verified: boolean;
-	email: string;
+// 사용자 DTO
+interface IUserDTO {
+	id?: number;
+	email?: string;
+	name?: string;
+	password?: string;
+	passwordHash?: string;
+	salt?: string;
+	cretedAt?: Date;
+	updatedAt?: Date;
 }
 
-interface IAccessInfo extends IJwtPayload {
-	userId: number;
+// 사용자 세션 DTO
+interface IUserSessionDTO {
+	id?: number;
+	clientId?: string;
+	userId?: number;
+	userName?: string;
+	userAgent?: string;
+	ipAddress?: string;
+	refreshToken?: string;
+	revoked?: boolean;
+	expiredAt?: Date;
+	cretedAt?: Date;
+	updatedAt?: Date;
+	lastAccessedAt?: Date;
 }
 
-interface IRefreshInfo extends IJwtPayload {
-	userId: number;
-	userAgent;
+// 토큰 DTO
+interface ITokenDTO {
+	token?: string;
+	secretKey?: string;
+	payload?: IAuthTokenPayload | IAccessTokenPayload | IRefreshTokenPayload;
+}
+
+interface IAuthTokenPayload extends JwtPayload {
+	verified?: boolean;
+}
+
+interface IAccessTokenPayload extends JwtPayload {}
+
+interface IRefreshTokenPayload extends JwtPayload {
+	clientId: string;
 }
 
 /**
@@ -67,12 +83,10 @@ interface IError extends Error {
 }
 
 export {
-	TVerificationsShema,
-	TUsersSchema,
 	IRequest,
-	TTokenDocodedInfos,
-	IAuthInfo,
-	IAccessInfo,
-	IRefreshInfo,
+	IVerificationDTO,
+	IUserDTO,
+	IUserSessionDTO,
+	ITokenDTO,
 	IError,
 };

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -21,14 +21,29 @@ type TVerificationsShema = {
 
 // express request에 token decoded 정보 추가
 interface IRequest extends Request {
-	tokenDecodedInfo: IAuthTokenPayload;
+	tokenDecodedInfos?: TTokenDocodedInfos;
 }
 
-interface IAuthTokenPayload extends JwtPayload {
-	verificationId: number;
+type TTokenDocodedInfos = {
+	authInfo?: IAuthInfo;
+	accessInfo?: IAccessInfo;
+	refreshInfo?: IRefreshInfo;
+};
+
+interface IJwtPayload extends JwtPayload {
+	jti: string;
+}
+
+interface IAuthInfo extends IJwtPayload {
 	verified: boolean;
 	email: string;
 }
+
+interface IAccessInfo extends IJwtPayload {
+	userName: boolean;
+}
+
+interface IRefreshInfo extends IJwtPayload {}
 
 /**
  * 에러 관련 타입 및 인터페이스
@@ -38,4 +53,12 @@ interface IError extends Error {
 	statusCode?: number;
 }
 
-export { TVerificationsShema, IRequest, IError, IAuthTokenPayload };
+export {
+	TVerificationsShema,
+	IRequest,
+	TTokenDocodedInfos,
+	IAuthInfo,
+	IAccessInfo,
+	IRefreshInfo,
+	IError,
+};

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -15,20 +15,30 @@ type TVerificationsShema = {
 	updated_at: Date;
 };
 
+// users 스키마
+type TUsersSchema = {
+	id: number;
+	email: string;
+	name: string;
+	password_hash: string;
+	salt: string;
+	creted_at: Date;
+	updated_at: Date;
+};
+
 /**
  * 토큰 관련 타입 및 인터페이스
  */
-
-// express request에 token decoded 정보 추가
-interface IRequest extends Request {
-	tokenDecodedInfos?: TTokenDocodedInfos;
-}
 
 type TTokenDocodedInfos = {
 	authInfo?: IAuthInfo;
 	accessInfo?: IAccessInfo;
 	refreshInfo?: IRefreshInfo;
 };
+
+interface IRequest extends Request {
+	tokenDecodedInfos?: TTokenDocodedInfos;
+}
 
 interface IJwtPayload extends JwtPayload {
 	jti: string;
@@ -40,10 +50,13 @@ interface IAuthInfo extends IJwtPayload {
 }
 
 interface IAccessInfo extends IJwtPayload {
-	userName: boolean;
+	userId: number;
 }
 
-interface IRefreshInfo extends IJwtPayload {}
+interface IRefreshInfo extends IJwtPayload {
+	userId: number;
+	userAgent;
+}
 
 /**
  * 에러 관련 타입 및 인터페이스
@@ -55,6 +68,7 @@ interface IError extends Error {
 
 export {
 	TVerificationsShema,
+	TUsersSchema,
 	IRequest,
 	TTokenDocodedInfos,
 	IAuthInfo,

--- a/server/src/utils/time.ts
+++ b/server/src/utils/time.ts
@@ -1,0 +1,4 @@
+const generateExp = (sec: number): number =>
+	Math.floor(Date.now() / 1000) + sec;
+
+export { generateExp };

--- a/server/src/validations/auth.validation.ts
+++ b/server/src/validations/auth.validation.ts
@@ -6,14 +6,14 @@ const emailSchema: Schema<DefaultSchemaKeys> = {
 };
 
 const cookieJWTSchema: Schema<DefaultSchemaKeys> = {
-	auth_token: {
+	authToken: {
 		in: ["cookies"],
 		isJWT: true,
 	},
 };
 
 const verifySchema: Schema<DefaultSchemaKeys> = {
-	auth_token: {
+	authToken: {
 		in: ["cookies"],
 		isJWT: true,
 	},

--- a/server/src/validations/user.validation.ts
+++ b/server/src/validations/user.validation.ts
@@ -2,7 +2,7 @@ import { Schema } from "express-validator";
 import { DefaultSchemaKeys } from "express-validator/lib/middlewares/schema";
 
 const registerSchema: Schema<DefaultSchemaKeys> = {
-	auth_token: {
+	authToken: {
 		in: ["cookies"],
 		isJWT: true,
 	},
@@ -35,6 +35,16 @@ const registerSchema: Schema<DefaultSchemaKeys> = {
 };
 
 const loginSchema: Schema<DefaultSchemaKeys> = {
+	refreshToken: {
+		in: ["cookies"],
+		isJWT: true,
+		optional: true,
+	},
+	accessToken: {
+		in: ["cookies"],
+		isJWT: true,
+		optional: true,
+	},
 	email: { in: ["body"], isEmail: true, normalizeEmail: true },
 	password: {
 		in: ["body"],

--- a/server/src/validations/user.validation.ts
+++ b/server/src/validations/user.validation.ts
@@ -34,4 +34,21 @@ const registerSchema: Schema<DefaultSchemaKeys> = {
 	},
 };
 
-export { registerSchema };
+const loginSchema: Schema<DefaultSchemaKeys> = {
+	email: { in: ["body"], isEmail: true, normalizeEmail: true },
+	password: {
+		in: ["body"],
+		isString: true,
+		isLength: {
+			errorMessage: "비밀번호는 최소 8자 이상, 20자 이하여야 합니다.",
+			options: { min: 8, max: 20 },
+		},
+		matches: {
+			errorMessage:
+				"비밀번호는 최소 하나의 소문자, 대문자, 숫자, 특수 문자를 포함해야 합니다.",
+			options: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\W_]).{8,}$/,
+		},
+	},
+};
+
+export { registerSchema, loginSchema };


### PR DESCRIPTION
## ✨ Summary

- 사용자 세션과 로그인 인증 및 인가 구현

## ✍🏻 Describe changes

- 인증 메일 리팩토링
- 로그인 기능 구현
- 로그인 이후 세션 DB에 관리 구현
- 기능 접근 인가 구현(refresh token, access token)

### test

- 토큰: access token의 만료기한은 10초, refresh token의 만료기한은 20초
- 토큰의 유무 및 만료 이후 사용자 세션이 잘 관리되는지 확인
- 테스트 엔드포인트는 `POST /api/users/test`

## 📌 Issue number

resolved: #11 
